### PR TITLE
Propriedade ``first_author``também no artigo. 

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1121,6 +1121,22 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.authors, expected)
 
+    def test_first_author_without_author(self):
+        article = self.article
+
+        del(article.data['article']['v10'])
+        self.assertEqual(article.first_author, None)
+
+    def test_first_author(self):
+        article = self.article
+
+        expected_author = {u'role': u'ND',
+                           u'xref': [u'A01'],
+                           u'surname': u'Gomes',
+                           u'given_names': u'Caio Isola Dallevo do Amaral'}
+
+        self.assertEqual(article.first_author, expected_author)
+
     def test_mixed_affiliations(self):
         article = self.article
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -814,6 +814,17 @@ class Article(object):
         return authors
 
     @property
+    def first_author(self):
+        """
+        This property try do get the first author of the article, otherwise
+        returns None.
+
+        :returns: dict with key ``surname``, ``given_names``, ``role`` adn ``xref``.
+        """
+        if self.authors:
+            return self.authors[0]
+
+    @property
     def corporative_authors(self):
         """
         This method retrieves the organizational authors of the given article, if it exists.


### PR DESCRIPTION
Essa propriedade retorna o primeiro autor do artigo seguindo a mesma idéia da citação.
