### PR TITLE
[tk151 e tk152] Alterações em analytic_institution e monographic_institution

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,6 +3,8 @@
 import unittest
 import json
 import os
+import warnings
+
 from xylose.scielodocument import Article, Citation, Journal, Issue, html_decode, UnavailableMetadataException
 from xylose import tools
 
@@ -4140,7 +4142,6 @@ class CitationTest(unittest.TestCase):
         ]
 
         citation = Citation(json_citation)
-
         self.assertEqual(
             citation.analytic_institution,
             [u'Article Institution', u'Article Institution 2']
@@ -4161,6 +4162,14 @@ class CitationTest(unittest.TestCase):
             citation.analytic_institution,
             [u'Book Institution', u'Book Institution 2']
         )
+
+    def test_pending_deprecation_warning_of_analytic_institution(self):
+        citation = Citation({})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert citation.analytic_institution is None
+            assert len(w) == 1
+            assert issubclass(w[-1].category, PendingDeprecationWarning)
 
     def test_analytic_institution_authors_for_an_article_citation(self):
         json_citation = {}

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4134,20 +4134,91 @@ class CitationTest(unittest.TestCase):
         json_citation['v30'] = [{u'_': u'It is the journal title'}]
         json_citation['v12'] = [{u'_': u'It is the article title'}]
         json_citation['v11'] = [{u'_': u'Article Institution'}]
+        json_citation['v11'] = [
+            {u'_': u'Article Institution'},
+            {u'_': u'Article Institution 2'},
+        ]
 
         citation = Citation(json_citation)
 
-        self.assertEqual(citation.analytic_institution, [u'Article Institution'])
+        self.assertEqual(
+            citation.analytic_institution,
+            [u'Article Institution', u'Article Institution 2']
+        )
 
     def test_analytic_institution_for_a_book_citation(self):
         json_citation = {}
 
         json_citation['v18'] = [{u'_': u'It is the book title'}]
-        json_citation['v11'] = [{u'_': u'Book Institution'}]
+        json_citation['v11'] = [
+            {u'_': u'Book Institution'},
+            {u'_': u'Book Institution 2'},
+        ]
 
         citation = Citation(json_citation)
 
-        self.assertEqual(citation.analytic_institution, [u'Book Institution'])
+        self.assertEqual(
+            citation.analytic_institution,
+            [u'Book Institution', u'Book Institution 2']
+        )
+
+    def test_analytic_institution_authors_for_an_article_citation(self):
+        json_citation = {}
+
+        json_citation['v30'] = [{u'_': u'It is the journal title'}]
+        json_citation['v12'] = [{u'_': u'It is the article title'}]
+        json_citation['v11'] = [{u'_': u'Article Institution'}]
+        json_citation['v11'] = [
+            {u'_': u'Article Institution'},
+            {u'_': u'Article Institution 2'},
+        ]
+        citation = Citation(json_citation)
+        self.assertEqual(
+            citation.analytic_institution_authors,
+            [u'Article Institution', u'Article Institution 2']
+        )
+
+    def test_analytic_institution_authors_for_a_book_citation(self):
+        json_citation = {}
+
+        json_citation['v18'] = [{u'_': u'It is the book title'}]
+        json_citation['v11'] = [
+            {u'_': u'Book Institution'},
+            {u'_': u'Book Institution 2'},
+        ]
+        citation = Citation(json_citation)
+        self.assertEqual(
+            citation.analytic_institution_authors,
+            [u'Book Institution', u'Book Institution 2']
+        )
+
+    def test_monographic_institution_authors_for_an_article_citation(self):
+        json_citation = {}
+
+        json_citation['v30'] = [{u'_': u'It is the journal title'}]
+        json_citation['v12'] = [{u'_': u'It is the article title'}]
+        json_citation['v17'] = [
+            {u'_': u'Article Institution'},
+            {u'_': u'Article Institution 2'},
+        ]
+        citation = Citation(json_citation)
+        self.assertEqual(
+            citation.monographic_institution_authors,
+            None
+        )
+
+    def test_monographic_institution_authors_for_a_book_citation(self):
+        json_citation = {}
+
+        json_citation['v18'] = [{u'_': u'It is the book title'}]
+        json_citation['v17'] = [
+            {u'_': u'Book Institution'},
+        ]
+        citation = Citation(json_citation)
+        self.assertEqual(
+            citation.monographic_institution_authors,
+            [u'Book Institution']
+        )
 
     def test_thesis_institution(self):
         json_citation = {}

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3581,7 +3581,7 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.thesis_organization, None)
 
-    @unittest.skip
+    @unittest.skip('skip test_citations')
     def test_citations(self):
         article = self.article
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -4166,8 +4166,16 @@ class CitationTest(unittest.TestCase):
     def test_pending_deprecation_warning_of_analytic_institution(self):
         citation = Citation({})
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            assert citation.analytic_institution is None
+            items = citation.analytic_institution
+            assert items is None
+            assert len(w) == 1
+            assert issubclass(w[-1].category, PendingDeprecationWarning)
+
+    def test_pending_deprecation_warning_of_monographic_institution(self):
+        citation = Citation({})
+        with warnings.catch_warnings(record=True) as w:
+            items = citation.monographic_institution
+            assert items is None
             assert len(w) == 1
             assert issubclass(w[-1].category, PendingDeprecationWarning)
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -52,6 +52,7 @@ REPLACE_TAGS_MIXED_CITATION = (
 
 
 def warn_future_deprecation(old, new, details=''):
+    warnings.simplefilter("always")
     msg = '"{}" will be deprected in future version. Use "{}" instead. {}'
     warnings.warn(msg, PendingDeprecationWarning)
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -5,6 +5,7 @@ import warnings
 import re
 import unicodedata
 import datetime
+import logging
 
 try:  # Keep compatibility with python 2.7
     from html import unescape
@@ -48,6 +49,10 @@ REPLACE_TAGS_MIXED_CITATION = (
     (re.compile(r'< *?small.*?>', re.IGNORECASE), '<small>',),
     (re.compile(r'< *?/ *?small.*?>', re.IGNORECASE), '</small>',),
 )
+
+
+def deprecation_msg(old, new, details=''):
+    return '"{}" will be deprected in future version. Use "{}" instead. {}'
 
 
 class XyloseException(Exception):
@@ -2819,33 +2824,77 @@ class Citation(object):
         if self.publication_type == 'article':
             return self.data.get('v35', None)
 
+    @property
+    def analytic_institution_authors(self):
+        """
+        It retrieves the analytic institution authors of a reference.
+        IT REPLACES the deprecated analytic_institution
+        """
+        institutions = []
+        if 'v12' in self.data or 'v18' in self.data:
+            for institution in self.data.get('v11', []):
+                institutions.append(html_decode(institution['_']))
+        if len(institutions) > 0:
+            return institutions
 
     @property
     def analytic_institution(self):
         """
         This method retrieves the institutions in the given citation. The
         citation must be an article or book citation, if it exists.
+        IT WILL BE DEPRECATED
         """
+        logging.info(
+            deprecation_msg(
+                'analytic_institution',
+                'analytic_institution_authors',
+                'analytic_institution_authors is more suitable name and '
+                'returns the authors independending on publication type'
+            )
+        )
         institutions = []
-        if self.publication_type in [u'article', u'book'] and 'v11' in self.data:
+        if self.publication_type in [u'article', u'book']:
             if 'v11' in self.data:
                 for institution in self.data['v11']:
-                    institutions.append(html_decode(self.data['v11'][0]['_']))
+                    institutions.append(html_decode(institution['_']))
 
         if len(institutions) > 0:
             return institutions
+
+    @property
+    def monographic_institution_authors(self):
+        """
+        It retrieves the monographic institution authors of a reference.
+        IT REPLACES the deprecated monographic_institution
+        """
+        if 'v18' in self.data:
+            institutions = []
+            for institution in self.data.get('v17', []):
+                institutions.append(html_decode(institution['_']))
+
+            if len(institutions) > 0:
+                return institutions
 
     @property
     def monographic_institution(self):
         """
         This method retrieves the institutions in the given citation. The
         citation must be a book citation, if it exists.
+        IT WILL BE DEPRECATED
         """
+        logging.info(
+            deprecation_msg(
+                'monographic_institution',
+                'monographic_institution_authors',
+                'monographic_institution_authors is more suitable name and '
+                'returns the authors independending on publication type'
+            )
+        )
         institutions = []
         if self.publication_type == u'book' and 'v17' in self.data:
             if 'v17' in self.data:
                 for institution in self.data['v17']:
-                    institutions.append(html_decode(self.data['v17'][0]['_']))
+                    institutions.append(html_decode(institution['_']))
 
         if len(institutions) > 0:
             return institutions

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -5,7 +5,7 @@ import warnings
 import re
 import unicodedata
 import datetime
-import logging
+import warnings
 
 try:  # Keep compatibility with python 2.7
     from html import unescape
@@ -51,8 +51,9 @@ REPLACE_TAGS_MIXED_CITATION = (
 )
 
 
-def deprecation_msg(old, new, details=''):
-    return '"{}" will be deprected in future version. Use "{}" instead. {}'
+def warn_future_deprecation(old, new, details=''):
+    msg = '"{}" will be deprected in future version. Use "{}" instead. {}'
+    warnings.warn(msg, PendingDeprecationWarning)
 
 
 class XyloseException(Exception):
@@ -2827,13 +2828,16 @@ class Citation(object):
     @property
     def analytic_institution_authors(self):
         """
-        It retrieves the analytic institution authors of a reference.
-        IT REPLACES the deprecated analytic_institution
+        It retrieves the analytic institution authors of a reference,
+        no matter the publication type of the reference.
+        It is not desirable to restrict the conditioned return to the
+        publication type, because some reference standards are very peculiar
+        and not only articles or books have institution authors.
+        IT REPLACES analytic_institution
         """
         institutions = []
-        if 'v12' in self.data or 'v18' in self.data:
-            for institution in self.data.get('v11', []):
-                institutions.append(html_decode(institution['_']))
+        for institution in self.data.get('v11', []):
+            institutions.append(html_decode(institution['_']))
         if len(institutions) > 0:
             return institutions
 
@@ -2844,13 +2848,11 @@ class Citation(object):
         citation must be an article or book citation, if it exists.
         IT WILL BE DEPRECATED
         """
-        logging.info(
-            deprecation_msg(
-                'analytic_institution',
-                'analytic_institution_authors',
-                'analytic_institution_authors is more suitable name and '
-                'returns the authors independending on publication type'
-            )
+        warn_future_deprecation(
+            'analytic_institution',
+            'analytic_institution_authors',
+            'analytic_institution_authors is more suitable name and '
+            'returns the authors independending on publication type'
         )
         institutions = []
         if self.publication_type in [u'article', u'book']:
@@ -2864,16 +2866,20 @@ class Citation(object):
     @property
     def monographic_institution_authors(self):
         """
-        It retrieves the monographic institution authors of a reference.
-        IT REPLACES the deprecated monographic_institution
+        It retrieves the monographic institution authors of a reference,
+        no matter the publication type of the reference.
+        It is not desirable to restrict the conditioned return to the
+        publication type, because some reference standards are very peculiar
+        and not only books have institution authors.
+        IT REPLACES monographic_institution
         """
-        if 'v18' in self.data:
-            institutions = []
-            for institution in self.data.get('v17', []):
-                institutions.append(html_decode(institution['_']))
-
-            if len(institutions) > 0:
-                return institutions
+        if 'v30' in self.data:
+            return
+        institutions = []
+        for institution in self.data.get('v17', []):
+            institutions.append(html_decode(institution['_']))
+        if len(institutions) > 0:
+            return institutions
 
     @property
     def monographic_institution(self):
@@ -2882,13 +2888,11 @@ class Citation(object):
         citation must be a book citation, if it exists.
         IT WILL BE DEPRECATED
         """
-        logging.info(
-            deprecation_msg(
-                'monographic_institution',
-                'monographic_institution_authors',
-                'monographic_institution_authors is more suitable name and '
-                'returns the authors independending on publication type'
-            )
+        warn_future_deprecation(
+            'monographic_institution',
+            'monographic_institution_authors',
+            'monographic_institution_authors is more suitable name and '
+            'returns the authors independending on publication type'
         )
         institutions = []
         if self.publication_type == u'book' and 'v17' in self.data:


### PR DESCRIPTION
- mantidos os atributos **analytic_institution** e **monographic_institution**
  - informar obsolescência
  - consertar um bug de retorno de **analytic_institutions** e **monographic_institutions** que quando havia mais de uma instituição retornava a primeira tantas vezes quanto era a quantidade de ocorrências.

- criados os atributos **analytic_institution_authors** e **monographic_institution_authors** (#152), que são nomes mais adequados que **analytic_institution** e **monographic_institution**
- não restringir o retorno condicionado com publication_type (#151), porque alguns padrões de referência são muito peculiares e não apenas livros ou artigos possuem autores institucionais.