### PR TITLE
[Tk154] Renomear analytic_authors e monographic_authors

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3581,7 +3581,7 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.thesis_organization, None)
 
-    @unittest.skip
+    @unittest.skip('skip test_citations')
     def test_citations(self):
         article = self.article
 
@@ -4297,6 +4297,98 @@ class CitationTest(unittest.TestCase):
         citation = Citation(json_citation)
 
         self.assertEqual(citation.authors, [])
+
+    def test_analytic_person_authors(self):
+        json_citation = {}
+
+        json_citation['v18'] = [{u'_': u'It is the book title'}]
+        json_citation['v12'] = [{u'_': u'It is the chapter title'}]
+        json_citation['v10'] = [{u's': u'Sullivan', u'n': u'Mike'},
+                                {u's': u'Hurricane Carter', u'n': u'Rubin'},
+                                {u's': u'Maguila Rodrigues', u'n': u'Adilson'},
+                                {u'n': u'Acelino Popó Freitas'},
+                                {u's': u'Zé Marreta'}]
+
+        expected = [{u'given_names': u'Mike', u'surname': u'Sullivan'},
+                    {u'given_names': u'Rubin', u'surname': u'Hurricane Carter'},
+                    {u'given_names': u'Adilson', u'surname': u'Maguila Rodrigues'},
+                    {u'given_names': u'Acelino Popó Freitas'},
+                    {u'surname': u'Zé Marreta'}]
+
+        citation = Citation(json_citation)
+
+        self.assertEqual(citation.analytic_person_authors, expected)
+
+    def test_without_analytic_person_authors(self):
+        json_citation = {}
+
+        json_citation['v18'] = [{u'_': u'It is the book title'}]
+        json_citation['v12'] = [{u'_': u'It is the chapter title'}]
+
+        citation = Citation(json_citation)
+
+        self.assertEqual(citation.analytic_person_authors, None)
+
+    def test_without_analytic_person_authors_but_not_a_book_citation(self):
+        json_citation = {}
+
+        json_citation['v30'] = [{u'_': u'It is the journal title'}]
+        json_citation['v12'] = [{u'_': u'It is the article title'}]
+        json_citation['v10'] = [{u's': u'Sullivan', u'n': u'Mike'},
+                                {u's': u'Hurricane Carter', u'n': u'Rubin'},
+                                {u's': u'Maguila Rodrigues', u'n': u'Adilson'},
+                                {u'n': u'Acelino Popó Freitas'},
+                                {u's': u'Zé Marreta'}]
+
+        expected = [{u'given_names': u'Mike', u'surname': u'Sullivan'},
+                    {u'given_names': u'Rubin', u'surname': u'Hurricane Carter'},
+                    {u'given_names': u'Adilson', u'surname': u'Maguila Rodrigues'},
+                    {u'given_names': u'Acelino Popó Freitas'},
+                    {u'surname': u'Zé Marreta'}]
+
+        citation = Citation(json_citation)
+
+        self.assertEqual(citation.analytic_person_authors, expected)
+
+    def test_monographic_person_authors(self):
+        json_citation = {}
+
+        json_citation['v18'] = [{u'_': u'It is the book title'}]
+        json_citation['v16'] = [{u's': u'Sullivan', u'n': u'Mike'},
+                                {u's': u'Hurricane Carter', u'n': u'Rubin'},
+                                {u's': u'Maguila Rodrigues', u'n': u'Adilson'},
+                                {u'n': u'Acelino Popó Freitas'},
+                                {u's': u'Zé Marreta'}]
+
+        expected = [{u'given_names': u'Mike', u'surname': u'Sullivan'},
+                    {u'given_names': u'Rubin', u'surname': u'Hurricane Carter'},
+                    {u'given_names': u'Adilson', u'surname': u'Maguila Rodrigues'},
+                    {u'given_names': u'Acelino Popó Freitas'},
+                    {u'surname': u'Zé Marreta'}]
+
+        citation = Citation(json_citation)
+
+        self.assertEqual(citation.monographic_person_authors, expected)
+
+    def test_without_monographic_person_authors(self):
+        json_citation = {}
+
+        json_citation['v18'] = [{u'_': u'It is the book title'}]
+        json_citation['v16'] = []
+
+        citation = Citation(json_citation)
+
+        self.assertEqual(citation.monographic_person_authors, None)
+
+    def test_without_monographic_person_authors_but_not_a_book_citation(self):
+        json_citation = {}
+
+        json_citation['v30'] = [{u'_': u'It is the journal title'}]
+        json_citation['v12'] = [{u'_': u'It is the article title'}]
+
+        citation = Citation(json_citation)
+
+        self.assertEqual(citation.monographic_person_authors, None)
 
     def test_monographic_authors(self):
         json_citation = {}

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3,6 +3,8 @@
 import unittest
 import json
 import os
+import warnings
+
 from xylose.scielodocument import Article, Citation, Journal, Issue, html_decode, UnavailableMetadataException
 from xylose import tools
 
@@ -4389,6 +4391,20 @@ class CitationTest(unittest.TestCase):
         citation = Citation(json_citation)
 
         self.assertEqual(citation.monographic_person_authors, None)
+
+    def test_pending_deprecation_warning_of_analytic_authors(self):
+        citation = Citation({})
+        with warnings.catch_warnings(record=True) as w:
+            assert citation.analytic_authors is None
+            assert len(w) == 1
+            assert issubclass(w[-1].category, PendingDeprecationWarning)
+
+    def test_pending_deprecation_warning_of_monographic_authors(self):
+        citation = Citation({})
+        with warnings.catch_warnings(record=True) as w:
+            self.assertEqual(citation.monographic_authors, None)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, PendingDeprecationWarning)
 
     def test_monographic_authors(self):
         json_citation = {}

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1,11 +1,10 @@
 # encoding: utf-8
 import sys
 from functools import wraps
-import warnings
 import re
 import unicodedata
 import datetime
-import logging
+import warnings
 
 try:  # Keep compatibility with python 2.7
     from html import unescape
@@ -51,8 +50,10 @@ REPLACE_TAGS_MIXED_CITATION = (
 )
 
 
-def deprecation_msg(old, new, details=''):
-    return '"{}" will be deprected in future version. Use "{}" instead. {}'
+def warn_future_deprecation(old, new, details=''):
+    warnings.simplefilter("always")
+    msg = '"{}" will be deprected in future version. Use "{}" instead. {}'
+    warnings.warn(msg, PendingDeprecationWarning)
 
 
 class XyloseException(Exception):
@@ -3017,20 +3018,22 @@ class Citation(object):
     @property
     def analytic_person_authors(self):
         """
-        This method retrieves the analytic person authors of a citation.
-        IT REPLACES the deprecated analytic_authors
+        It retrieves the analytic person authors of a reference,
+        no matter the publication type of the reference.
+        It is not desirable to restrict the conditioned return to the
+        publication type, because some reference standards are very peculiar
+        and not only articles or books have person authors.
+        IT REPLACES analytic_authors
         """
         authors = []
-        if 'v12' in self.data:
-            for author in self.data.get('v10', []):
-                authordict = {}
-                if 's' in author:
-                    authordict['surname'] = html_decode(author['s'])
-                if 'n' in author:
-                    authordict['given_names'] = html_decode(author['n'])
-                if 's' in author or 'n' in author:
-                    authors.append(authordict)
-
+        for author in self.data.get('v10', []):
+            authordict = {}
+            if 's' in author:
+                authordict['surname'] = html_decode(author['s'])
+            if 'n' in author:
+                authordict['given_names'] = html_decode(author['n'])
+            if 's' in author or 'n' in author:
+                authors.append(authordict)
         if len(authors) > 0:
             return authors
 
@@ -3041,12 +3044,10 @@ class Citation(object):
         may correspond to an article, book analytic, link or thesis.
         IT WILL BE DEPRECATED. Use analytic_person_authors instead
         """
-        logging.info(
-            deprecation_msg(
+        warn_future_deprecation(
                 'analytic_authors',
                 'analytic_person_authors',
                 'analytic_person_authors is more suitable name'
-            )
         )
         authors = []
         if 'v10' in self.data:
@@ -3065,20 +3066,22 @@ class Citation(object):
     @property
     def monographic_person_authors(self):
         """
-        This method retrieves the monographic person authors of citation.
-        IT REPLACES the deprecated monographic_authors
+        It retrieves the monographic person authors of a reference,
+        no matter the publication type of the reference.
+        It is not desirable to restrict the conditioned return to the
+        publication type, because some reference standards are very peculiar
+        and not only articles or books have person authors.
+        IT REPLACES monographic_authors
         """
         authors = []
-        if 'v18' in self.data:
-            for author in self.data.get('v16', []):
-                authordict = {}
-                if 's' in author:
-                    authordict['surname'] = html_decode(author['s'])
-                if 'n' in author:
-                    authordict['given_names'] = html_decode(author['n'])
-                if 's' in author or 'n' in author:
-                    authors.append(authordict)
-
+        for author in self.data.get('v16', []):
+            authordict = {}
+            if 's' in author:
+                authordict['surname'] = html_decode(author['s'])
+            if 'n' in author:
+                authordict['given_names'] = html_decode(author['n'])
+            if 's' in author or 'n' in author:
+                authors.append(authordict)
         if len(authors) > 0:
             return authors
 
@@ -3090,12 +3093,10 @@ class Citation(object):
         correspond to a book monography citation.
         IT WILL BE DEPRECATED. Use monographic_person_authors instead.
         """
-        logging.info(
-            deprecation_msg(
+        warn_future_deprecation(
                 'monographic_authors',
                 'monographic_person_authors',
                 'monographic_person_authors is more suitable name'
-            )
         )
         authors = []
         if 'v16' in self.data:

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -5,6 +5,7 @@ import warnings
 import re
 import unicodedata
 import datetime
+import logging
 
 try:  # Keep compatibility with python 2.7
     from html import unescape
@@ -48,6 +49,10 @@ REPLACE_TAGS_MIXED_CITATION = (
     (re.compile(r'< *?small.*?>', re.IGNORECASE), '<small>',),
     (re.compile(r'< *?/ *?small.*?>', re.IGNORECASE), '</small>',),
 )
+
+
+def deprecation_msg(old, new, details=''):
+    return '"{}" will be deprected in future version. Use "{}" instead. {}'
 
 
 class XyloseException(Exception):
@@ -3010,12 +3015,39 @@ class Citation(object):
         return aa + ma
 
     @property
+    def analytic_person_authors(self):
+        """
+        This method retrieves the analytic person authors of a citation.
+        IT REPLACES the deprecated analytic_authors
+        """
+        authors = []
+        if 'v12' in self.data:
+            for author in self.data.get('v10', []):
+                authordict = {}
+                if 's' in author:
+                    authordict['surname'] = html_decode(author['s'])
+                if 'n' in author:
+                    authordict['given_names'] = html_decode(author['n'])
+                if 's' in author or 'n' in author:
+                    authors.append(authordict)
+
+        if len(authors) > 0:
+            return authors
+
+    @property
     def analytic_authors(self):
         """
         This method retrieves the authors of the given citation. These authors
         may correspond to an article, book analytic, link or thesis.
+        IT WILL BE DEPRECATED. Use analytic_person_authors instead
         """
-
+        logging.info(
+            deprecation_msg(
+                'analytic_authors',
+                'analytic_person_authors',
+                'analytic_person_authors is more suitable name'
+            )
+        )
         authors = []
         if 'v10' in self.data:
             for author in self.data['v10']:
@@ -3031,12 +3063,40 @@ class Citation(object):
             return authors
 
     @property
+    def monographic_person_authors(self):
+        """
+        This method retrieves the monographic person authors of citation.
+        IT REPLACES the deprecated monographic_authors
+        """
+        authors = []
+        if 'v18' in self.data:
+            for author in self.data.get('v16', []):
+                authordict = {}
+                if 's' in author:
+                    authordict['surname'] = html_decode(author['s'])
+                if 'n' in author:
+                    authordict['given_names'] = html_decode(author['n'])
+                if 's' in author or 'n' in author:
+                    authors.append(authordict)
+
+        if len(authors) > 0:
+            return authors
+
+    @property
     def monographic_authors(self):
         """
-        This method retrieves the authors of the given book citation. These authors may
+        This method retrieves the authors of the given book citation.
+        These authors may
         correspond to a book monography citation.
+        IT WILL BE DEPRECATED. Use monographic_person_authors instead.
         """
-
+        logging.info(
+            deprecation_msg(
+                'monographic_authors',
+                'monographic_person_authors',
+                'monographic_person_authors is more suitable name'
+            )
+        )
         authors = []
         if 'v16' in self.data:
             for author in self.data['v16']:


### PR DESCRIPTION
- Copiados analytic_authors e monographic_authors e, respectivamente, nomeados para analytic_person_authors e monographic_person_authors.
- Incluir indicação de obsolescência

Fixes #154