### PR TITLE
Inclusão dos campos number_label e special_number no Issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
 
 setup(
     name="xylose",
-    version='1.33.2',
+    version='1.33.3',
     description="A SciELO library to abstract a JSON data structure that is a "
                 "product of the ISIS2JSON conversion using the ISIS2JSON type "
                 "3 data model.",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -757,15 +757,25 @@ class IssueTests(unittest.TestCase):
 
         self.assertTrue(self.issue.collection_acronym, '')
 
+    def test_issue_number_label(self):
+        self.issue.data['issue']['v32'] = [{u'_': u'2'}]
+        self.assertEqual(self.issue.number_label, u'2')
+        self.issue.data['issue']['v32'] = [{u'_': u'0'}]
+        self.assertEqual(self.issue.number_label, u'')
+        self.issue.data['issue']['v32'] = [{u'_': u'5'}]
+        self.assertEqual(self.issue.number_label, u'5')
+        del self.issue.data['issue']['v32']
+        self.assertEqual(self.issue.number_label, u'')
+
     def test_special_number_label(self):
         self.issue.data['issue']['v32'] = [{u'_': u'spe'}]
         self.assertEqual(self.issue.number_label, u'')
         self.issue.data['issue']['v32'] = [{u'_': u'spe2'}]
-        self.assertEqual(self.issue.number_label, u'2')
-        self.issue.data['issue']['v32'] = [{u'_': u'5spe'}]
         self.assertEqual(self.issue.number_label, u'')
+        self.issue.data['issue']['v32'] = [{u'_': u'5spe'}]
+        self.assertEqual(self.issue.number_label, u'5')
         self.issue.data['issue']['v32'] = [{u'_': u'5spe3'}]
-        self.assertEqual(self.issue.number_label, u'3')
+        self.assertEqual(self.issue.number_label, u'5')
 
     def test_supplement_number_label(self):
         self.issue.data['issue']['v132'] = [{u'_': u'2'}]
@@ -777,23 +787,25 @@ class IssueTests(unittest.TestCase):
         self.issue.data['issue']['v32'] = [{u'_': u'1'}]
         self.assertEqual(self.issue.number_label, u'')
 
-    def test_special_number(self):
+    def test_special_label(self):
         del self.issue.data['issue']['v32']
-        self.assertEqual(self.issue.special_number, u'')
+        self.assertEqual(self.issue.special_label, u'')
         self.issue.data['issue']['v32'] = [{u'_': u'2'}]
-        self.assertEqual(self.issue.special_number, u'2')
+        self.assertEqual(self.issue.special_label, u'')
         self.issue.data['issue']['v32'] = [{u'_': u'spe'}]
-        self.assertEqual(self.issue.special_number, None)
+        self.assertEqual(self.issue.special_label, u'')
         self.issue.data['issue']['v32'] = [{u'_': u'spe3'}]
-        self.assertEqual(self.issue.special_number, None)
+        self.assertEqual(self.issue.special_label, u'3')
         self.issue.data['issue']['v32'] = [{u'_': u'2spe'}]
-        self.assertEqual(self.issue.special_number, u'2')
+        self.assertEqual(self.issue.special_label, u'')
+        self.issue.data['issue']['v32'] = [{u'_': u'2spe4'}]
+        self.assertEqual(self.issue.special_label, u'4')
         self.issue.data['issue']['v32'] = [{u'_': u'10spe'}]
-        self.assertEqual(self.issue.special_number, u'10')
+        self.assertEqual(self.issue.special_label, u'')
         self.issue.data['issue']['v32'] = [{u'_': u'5spe.1'}]
-        self.assertEqual(self.issue.special_number, u'5')
+        self.assertEqual(self.issue.special_label, u'1')
         self.issue.data['issue']['v32'] = [{u'_': u'3spe-2'}]
-        self.assertEqual(self.issue.special_number, u'3')
+        self.assertEqual(self.issue.special_label, u'2')
 
 
 class JournalTests(unittest.TestCase):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -762,6 +762,10 @@ class IssueTests(unittest.TestCase):
         self.assertEqual(self.issue.number_label, u'')
         self.issue.data['issue']['v32'] = [{u'_': u'spe2'}]
         self.assertEqual(self.issue.number_label, u'2')
+        self.issue.data['issue']['v32'] = [{u'_': u'5spe'}]
+        self.assertEqual(self.issue.number_label, u'')
+        self.issue.data['issue']['v32'] = [{u'_': u'5spe3'}]
+        self.assertEqual(self.issue.number_label, u'3')
 
     def test_supplement_number_label(self):
         self.issue.data['issue']['v132'] = [{u'_': u'2'}]
@@ -772,6 +776,24 @@ class IssueTests(unittest.TestCase):
         self.issue.data['issue']['v132'] = [{u'_': u'0'}]
         self.issue.data['issue']['v32'] = [{u'_': u'1'}]
         self.assertEqual(self.issue.number_label, u'')
+
+    def test_special_number(self):
+        del self.issue.data['issue']['v32']
+        self.assertEqual(self.issue.special_number, u'')
+        self.issue.data['issue']['v32'] = [{u'_': u'2'}]
+        self.assertEqual(self.issue.special_number, u'2')
+        self.issue.data['issue']['v32'] = [{u'_': u'spe'}]
+        self.assertEqual(self.issue.special_number, None)
+        self.issue.data['issue']['v32'] = [{u'_': u'spe3'}]
+        self.assertEqual(self.issue.special_number, None)
+        self.issue.data['issue']['v32'] = [{u'_': u'2spe'}]
+        self.assertEqual(self.issue.special_number, u'2')
+        self.issue.data['issue']['v32'] = [{u'_': u'10spe'}]
+        self.assertEqual(self.issue.special_number, u'10')
+        self.issue.data['issue']['v32'] = [{u'_': u'5spe.1'}]
+        self.assertEqual(self.issue.special_number, u'5')
+        self.issue.data['issue']['v32'] = [{u'_': u'3spe-2'}]
+        self.assertEqual(self.issue.special_number, u'3')
 
 
 class JournalTests(unittest.TestCase):

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -755,7 +755,23 @@ class IssueTests(unittest.TestCase):
 
     def test_collection_acronym(self):
 
-        self.assertTrue(self.issue.url, '')
+        self.assertTrue(self.issue.collection_acronym, '')
+
+    def test_special_number_label(self):
+        self.issue.data['issue']['v32'] = [{u'_': u'spe'}]
+        self.assertEqual(self.issue.number_label, u'')
+        self.issue.data['issue']['v32'] = [{u'_': u'spe2'}]
+        self.assertEqual(self.issue.number_label, u'2')
+
+    def test_supplement_number_label(self):
+        self.issue.data['issue']['v132'] = [{u'_': u'2'}]
+        del self.issue.data['issue']['v32']
+        self.assertEqual(self.issue.number_label, u'2')
+        self.issue.data['issue']['v32'] = [{u'_': u'3'}]
+        self.assertEqual(self.issue.number_label, u'2')
+        self.issue.data['issue']['v132'] = [{u'_': u'0'}]
+        self.issue.data['issue']['v32'] = [{u'_': u'1'}]
+        self.assertEqual(self.issue.number_label, u'')
 
 
 class JournalTests(unittest.TestCase):
@@ -5215,9 +5231,9 @@ class CitationTest(unittest.TestCase):
 
     def test_citation_sample_congress(self):
 
-        json_citation= {u'v999': 
+        json_citation= {u'v999':
             [{u'_': u'../bases-work/ciedu/ciedu'}],
-             u'v12': 
+             u'v12':
                 [{u'l': u'es',
                 u'_': u'Escuelas con poblaciones en riesgo social: proyecto de intervenci\xf3n e investigaci\xf3n en el \xe1rea de ciencias naturales'}], u'v10': [{u's': u'G\xd3MEZ',
                 u'r': u'ND',

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -324,9 +324,9 @@ class Issue(object):
             '2' == '2'
             '0' == '' (it does not exist)
             'spe' == ''
-            'spe3' == '3'
-            '5spe' == ''
-            '5spe3' == '3'
+            'spe3' == ''
+            '5spe' == '5'
+            '5spe3' == '5'
         """
         label = self.number if self.number and self.number != '0' else ''
         if self.type == 'special':

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -325,10 +325,13 @@ class Issue(object):
             '0' == '0'
             'spe' == ''
             'spe3' == '3'
+            '5spe' == ''
+            '5spe3' == '3'
         """
         label = self.number or ''
         if self.type == 'special':
-            label = ''.join([d for d in self.number if d.isdigit()])
+            digits = re.findall(r'\d+$', self.number)
+            label = digits[0] if digits else ''
         elif self.type == 'supplement':
             label = self.supplement_number if self.supplement_number \
                 and self.supplement_number != '0' else ''
@@ -351,6 +354,26 @@ class Issue(object):
         """
         if 'v32' in self.data['issue']:
             return self.data['issue']['v32'][0]['_']
+
+    @property
+    def special_number(self):
+        """
+        This method retrieves the issue number of the given issue, if it exists.
+        This method deals with different format of numbers.
+        E.g.:
+            '2' == '2'
+            'spe' == None
+            'spe3' == None
+            '2spe' == '2'
+            '10spe' == '10'
+            '5spe.1' == '5'
+            '3spe-2' == '3'
+        """
+        special = self.number or ''
+        if self.number:
+            digits = re.findall(r'^\d+', self.number)
+            special = digits[0] if digits else None
+        return special
 
     @property
     def _start_end_months(self):

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -322,15 +322,15 @@ class Issue(object):
         shown when there is label translation.
         E.g.:
             '2' == '2'
-            '0' == '0'
+            '0' == '' (it does not exist)
             'spe' == ''
             'spe3' == '3'
             '5spe' == ''
             '5spe3' == '3'
         """
-        label = self.number or ''
+        label = self.number if self.number and self.number != '0' else ''
         if self.type == 'special':
-            digits = re.findall(r'\d+$', self.number)
+            digits = re.findall(r'^\d+', self.number)
             label = digits[0] if digits else ''
         elif self.type == 'supplement':
             label = self.supplement_number if self.supplement_number \
@@ -356,23 +356,25 @@ class Issue(object):
             return self.data['issue']['v32'][0]['_']
 
     @property
-    def special_number(self):
+    def special_label(self):
         """
-        This method retrieves the issue number of the given issue, if it exists.
+        This method retrieves the special issue number of the given issue, if
+        it exists.
         This method deals with different format of numbers.
         E.g.:
-            '2' == '2'
-            'spe' == None
-            'spe3' == None
-            '2spe' == '2'
-            '10spe' == '10'
-            '5spe.1' == '5'
-            '3spe-2' == '3'
+            '2' == '' (it is not an special issue)
+            'spe' == '' (there is no number in this special issue)
+            'spe3' == '3'
+            '2spe' == ''
+            '2spe4' == '4'
+            '10spe' == ''
+            '5spe.1' == '1'
+            '3spe-2' == '2'
         """
-        special = self.number or ''
-        if self.number:
-            digits = re.findall(r'^\d+', self.number)
-            special = digits[0] if digits else None
+        special = ''
+        if self.number and self.type == 'special':
+            digits = re.findall(r'\d+$', self.number)
+            special = digits[0] if digits else ''
         return special
 
     @property

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -316,6 +316,25 @@ class Issue(object):
         return label
 
     @property
+    def number_label(self):
+        """
+        This method retrieves the issue number label to provide the number to be
+        shown when there is label translation.
+        E.g.:
+            '2' == '2'
+            '0' == '0'
+            'spe' == ''
+            'spe3' == '3'
+        """
+        label = self.number or ''
+        if self.type == 'special':
+            label = ''.join([d for d in self.number if d.isdigit()])
+        elif self.type == 'supplement':
+            label = self.supplement_number if self.supplement_number \
+                and self.supplement_number != '0' else ''
+        return label
+
+    @property
     def volume(self):
         """
         This method retrieves the issue volume of the given issue, if it exists.


### PR DESCRIPTION
`number_label`: campo que retorna um label numérico para identificação de um fascículo, sendo ele de um número ou de um volume.
Ex:
- '2' == '2'
- '0' == '0'
- 'spe' == ''
- 'spe3' == '3'
- '5spe' == ''
- '5spe3' == '3'

`special_number`: campo que retorna o número do fascículo, sendo ele número especial ou não.
Ex:
- '2' == '2'
- 'spe' == None
- 'spe3' == None
- '2spe' == '2'
- '10spe' == '10'
- '5spe.1' == '5'
- '3spe-2' == '3'
