### PR TITLE
Add Journal.new_title property for the v710 field

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -860,6 +860,11 @@ class JournalTests(unittest.TestCase):
 
         self.assertEqual(journal.previous_title, None)
 
+    def test_next_title(self):
+        self.assertEqual(self.journal.next_title, None)
+        self.journal.data['v710'] = [{'_': u'It has a new title!'}]
+        self.assertEqual(self.journal.next_title, u'It has a new title!')
+
     def test_in_scie(self):
         journal = self.journal
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1220,6 +1220,13 @@ class Journal(object):
         return self.data.get('v100', [{'_': None}])[0]['_']
 
     @property
+    def next_title(self):
+        """
+        New/next journal title from its legacy field (710).
+        """
+        return self.data.get('v710', [{'_': None}])[0]['_']
+
+    @property
     def publisher_country(self):
         """
         This method retrieves the publisher country of journal.


### PR DESCRIPTION
Although this PR names property for the v710 field as `new_title` matching the description text in the SciELO's model dictionary, it's perhaps more appropriate to rename this new property to `next_title`, since the property with the old title is named as `previous_title`. Is `new_title` ok, should I rename it to `next_title`, or should all properties exist like:

- `old_title` returning the same as `previous_title`; and
- `new_title` returning the same as `next_title`?

It's a field I've used in the deindexing reason notebook written for the SciELO 20 Years WG6.