### PR TITLE
[opac][tk995] Correção em Article.original_section e Article.translated_sections

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1956,19 +1956,10 @@ class ArticleTests(unittest.TestCase):
         article = Article(self.fulldoc)
         self.assertEqual(article.original_section(), u'label en')
 
-        with warnings.catch_warnings(record=True) as w:
-            article.original_section()
-            self.assertIs(w[-1].category, PendingDeprecationWarning)
-
     def test_translated_section_field_v49(self):
         self.fulldoc['section'] = {u'en': u'label en', u'pt': u'label pt', u'es': 'label es'}
-
         article = Article(self.fulldoc)
-
         self.assertEqual(sorted([k+v for k, v in article.translated_section().items()]), [u'eslabel es', 'ptlabel pt'])
-        with warnings.catch_warnings(record=True) as w:
-            article.translated_section()
-            self.assertIs(w[-1].category, PendingDeprecationWarning)
 
     def test_section_field_v49(self):
         self.fulldoc['section'] = {u'en': u'label en', u'pt': u'label pt'}

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1953,10 +1953,12 @@ class ArticleTests(unittest.TestCase):
 
     def test_original_section_field_v49(self):
         self.fulldoc['section'] = {u'en': u'label en', u'pt': u'label pt', u'es': 'label es'}
-
         article = Article(self.fulldoc)
-
         self.assertEqual(article.original_section(), u'label en')
+
+        with warnings.catch_warnings(record=True) as w:
+            article.original_section()
+            self.assertIs(w[-1].category, PendingDeprecationWarning)
 
     def test_translated_section_field_v49(self):
         self.fulldoc['section'] = {u'en': u'label en', u'pt': u'label pt', u'es': 'label es'}
@@ -1964,6 +1966,9 @@ class ArticleTests(unittest.TestCase):
         article = Article(self.fulldoc)
 
         self.assertEqual(sorted([k+v for k, v in article.translated_section().items()]), [u'eslabel es', 'ptlabel pt'])
+        with warnings.catch_warnings(record=True) as w:
+            article.translated_section()
+            self.assertIs(w[-1].category, PendingDeprecationWarning)
 
     def test_section_field_v49(self):
         self.fulldoc['section'] = {u'en': u'label en', u'pt': u'label pt'}

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1598,15 +1598,9 @@ class Article(object):
         return self.issue.is_ahead_of_print
 
     def original_section(self, iso_format=None):
-        warn_future_deprecation(
-            'original_section', 'section',
-            'section returns a dict which items are languages and titles')
         return self.section.get(self.original_language(iso_format))
 
     def translated_section(self, iso_format=None):
-        warn_future_deprecation(
-            'translated_section', 'section',
-            'section returns a dict which items are languages and titles')
         return {k: v
                 for k, v in self.section.items()
                 if k != self.original_language(iso_format)}

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1598,12 +1598,14 @@ class Article(object):
         return self.issue.is_ahead_of_print
 
     def original_section(self, iso_format=None):
-        return self.section.get(self.original_language(iso_format))
+        if self.section:
+            return self.section.get(self.original_language(iso_format))
 
     def translated_section(self, iso_format=None):
-        return {k: v
-                for k, v in self.section.items()
-                if k != self.original_language(iso_format)}
+        if self.section:
+            return {k: v
+                    for k, v in self.section.items()
+                    if k != self.original_language(iso_format)}
 
     @property
     def section(self):

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1598,18 +1598,18 @@ class Article(object):
         return self.issue.is_ahead_of_print
 
     def original_section(self, iso_format=None):
-
-        if not 'section' in self.data:
-            return None
-
-        return self.data['section'].get(self.original_language(iso_format), None)
+        warn_future_deprecation(
+            'original_section', 'section',
+            'section returns a dict which items are languages and titles')
+        return self.section.get(self.original_language(iso_format))
 
     def translated_section(self, iso_format=None):
-
-        if not 'section' in self.data:
-            return None
-
-        return {k: v for k, v in self.data['section'].items() if k != self.original_language(iso_format)}
+        warn_future_deprecation(
+            'translated_section', 'section',
+            'section returns a dict which items are languages and titles')
+        return {k: v
+                for k, v in self.section.items()
+                if k != self.original_language(iso_format)}
 
     @property
     def section(self):


### PR DESCRIPTION
### What's this PR do?
**_Article.original_section_** e **_Article.translated_sections_** exigiam que a existência de **_data['section']_**. No entanto, **_data['section']_** não está sendo mais gerado, pois o processamento **_load_sections_** parou de ser executado e isso deve se manter assim. Por outro lado, já data contém dados suficientes para retornar **original_section** e **translated_sections**. Então, este PR retorna corretamente os dados de **original_section** e **translated_sections**, usando **Article.section**.

### Where should the reviewer start?
scielodocument.py

### How should this be manually tested?
```
>>> from articlemeta.client import RestfulClient
>>> from xylose.scielodocument import Article
>>> cl = RestfulClient()
>>> at = cl.document(code="S0102-311X2018000105001", collection="scl")
>>> at.section
{'pt': 'Artigo', 'en': 'Article'}
>>> article = Article(at)
>>> article.original_section()
>>> article.translated_sections()
{'pt': 'Artigo', 'en': 'Article'}
```

### Any background context you want to provide?
Problema foi detectado no opac

### What are the relevant tickets?
https://github.com/scieloorg/opac/issues/995


opac_tk995a