### PR TITLE
[tk166] Resolve Quebra na versão 1.35.0 da compatibilidade com Articl…

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1987,6 +1987,10 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.section, None)
 
+    def test_section_in_data_which_has_no_title_data_and_no_issue_data(self):
+        article = Article({'article': {}})
+        self.assertEqual(article.section, None)
+
     def test_section_without_field_section(self):
         """
         Article without field section trying to load section from issue metadata

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1626,8 +1626,8 @@ class Article(object):
         if section:
             return section
 
-        return self.issue.sections.get(self.section_code or '', None) if self.issue.sections else None
-
+        if 'issue' in self.data and self.issue.sections:
+            return self.issue.sections.get(self.section_code or '', None)
 
     @property
     def section_code(self):


### PR DESCRIPTION
…e Meta

#### What's this PR do?
Corrige o problema de quebra na versão 1.35.0. O problema ocorre porque nem sempre há dados de periódico ou de fascículo, há apenas dados de artigo e, o atributo Article.section não estava considerando isso, resultando no levantamento de uma exceção.

#### Where should the reviewer start?
test_document.py

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
Article tem dados de periódico e fascículo quando instanciado com dados da "base". 
Article tem somente dados de artigo quando instanciado com dados de XML.

#### What are the relevant tickets?
#166 

#### Screenshots (if appropriate)
N/A
