### PR TITLE
[DOIMultilingue] Incluir atributo Article.doi_and_lang para retornar …

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3603,7 +3603,117 @@ class ArticleTests(unittest.TestCase):
 
         article.data['citations']
 
-        #self.assertTrue(article.citations, Citations)
+    def test_doi_and_lang_from_v337(self):
+        data = [
+            {u'l': u'pt', 'd': '10.1590/blabla.pt'},
+            {u'l': u'en', 'd': '10.1590/blabla.en'},
+            {u'l': u'es', 'd': '10.1590/blabla.es'},
+        ]
+        expected = [
+            ('pt', '10.1590/blabla.pt'),
+            ('en', '10.1590/blabla.en'),
+            ('es', '10.1590/blabla.es'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'pt'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
+        doc['article']['v337'] = data
+        article = Article(doc)
+        self.assertEqual(article.doi_and_lang, expected)
+
+    def test_doi_and_lang_from_data(self):
+        data = [
+            {u'l': u'pt', 'd': '10.1590/blabla.pt'},
+            {u'l': u'en', 'd': '10.1590/blabla.en'},
+            {u'l': u'es', 'd': '10.1590/blabla.es'},
+        ]
+        expected = [
+            ('pt', '10.1590/blabla.pt'),
+            ('en', '10.1590/blabla.en'),
+            ('es', '10.1590/blabla.es'),
+        ]
+
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'pt'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
+        doc['article']['v337'] = data
+        article = Article(doc)
+        article.data['doi_and_lang'] = data
+        self.assertEqual(article.doi_and_lang, expected)
+
+    def test_doi_and_lang_from_v337_with_bad_format(self):
+        data = [
+            {u'l': u'pt', 'd': '10.1590/blabla.pt'},
+            {u'l': u'en', 'd': '10.1590/blabla.en'},
+            {u'l': u'es', 'd': '10.1590'},
+        ]
+        expected = [
+            ('pt', '10.1590/blabla.pt'),
+            ('en', '10.1590/blabla.en'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'pt'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
+        doc['article']['v337'] = data
+        article = Article(doc)
+
+        self.assertEqual(article.doi_and_lang, expected)
+
+    def test_doi_and_lang_from_data_with_bad_format(self):
+        data = [
+            {u'l': u'pt', 'd': '10.1590/blabla.pt'},
+            {u'l': u'en', 'd': '10.1590/blabla.en'},
+            {u'l': u'es', 'd': 'blabla.es'},
+        ]
+        expected = [
+            ('pt', '10.1590/blabla.pt'),
+            ('en', '10.1590/blabla.en'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'pt'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
+        article = Article(doc)
+        article.data['doi_and_lang'] = data
+        self.assertEqual(article.doi_and_lang, expected)
+
+    def test_doi_and_lang_exist_v237_in_v337(self):
+        data = [
+            {u'l': u'en', 'd': '10.1590/blabla.en'},
+            {u'l': u'es', 'd': '10.1590/blabla.es'},
+        ]
+        expected = [
+            ('fr', '10.1590/blabla.fr'),
+            ('en', '10.1590/blabla.en'),
+            ('es', '10.1590/blabla.es'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'fr'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.fr'}]
+        doc['article']['v337'] = data
+        article = Article(doc)
+        self.assertEqual(article.doi_and_lang, expected)
+
+    def test_doi_and_lang_main_doi_does_not_exist(self):
+        data = [
+            {u'l': u'en', 'd': '10.1590/blabla.en'},
+            {u'l': u'es', 'd': '10.1590/blabla.es'},
+        ]
+        expected = [
+            ('en', '10.1590/blabla.en'),
+            ('es', '10.1590/blabla.es'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'fr'}]
+        doc['article']['v237'] = [{'_': ''}]
+        doc['article']['v337'] = data
+        article = Article(doc)
+        self.assertEqual(article.doi_and_lang, expected)
 
 
 class CitationTest(unittest.TestCase):

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2075,6 +2075,24 @@ class Article(object):
             return doi[0]
 
     @property
+    def doi_and_lang(self):
+        """
+        This method retrieves the lang and DOI.
+        """
+        raw_doi = self.data.get('doi_and_lang') or \
+            self.data.get('article', {}).get('v337')
+        if raw_doi:
+            items = [
+                tuple(item.values())
+                for item in raw_doi or []
+                if len(DOI_REGEX.findall(item.get('d'))) == 1
+            ]
+            item = (self.original_language(), self.doi)
+            if all(item) and item not in items:
+                items.insert(0, item)
+            return items
+
+    @property
     def publisher_id(self):
         """
         This method retrieves the publisher id of the given article, if it exists.


### PR DESCRIPTION
…os DOI de cada versão de idioma

tk168

#### O que esse PR faz?
Incluir atributo Article.doi_and_lang para retornar os DOI de cada versão de idioma

#### Onde a revisão poderia começar?
tests/test_document.py

#### Como este poderia ser testado manualmente?
```
>>> from articlemeta.client import RestfulClient
>>> from xylose.scielodocument import Article
>>> cl = RestfulClient()
>>> at = cl.document(code="S0102-311X2018000105001", collection="scl")
>>> article = Article(at)
>>> article.doi_and_lang
[('en', '10.1590/0102-311x00204016')]
```
#### Algum cenário de contexto que queira dar?
Este dado é proveniente do campo v337 gerado pelo XML Converter na base ISIS do artigo,  populado pelo XML com o valor de sub-article/@language e sub-article//front-stub//article-id[@pub-id-type='doi']

```xml
<article dtd-version="1.1">
...
<sub-article language="en" ... >
...
<article-id pub-id-type="doi">10.1128/JCM.39.7.2634-2636.2001</article-id>
...
```
### Screenshots
N/A

#### Quais são tickets relevantes?
#168 

### Referências
N/A

