### PR TITLE
xylose_correcao_de_1.35.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
 
 setup(
     name="xylose",
-    version='1.35.2',
+    version='1.35.3',
     description="A SciELO library to abstract a JSON data structure that is a "
                 "product of the ISIS2JSON conversion using the ISIS2JSON type "
                 "3 data model.",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3603,6 +3603,17 @@ class ArticleTests(unittest.TestCase):
 
         article.data['citations']
 
+    def test_doi_and_lang_from_v237(self):
+        expected = [
+            ('pt', '10.1590/blabla.pt'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'pt'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
+        article = Article(doc)
+        self.assertEqual(article.doi_and_lang, expected)
+
     def test_doi_and_lang_from_v337(self):
         data = [
             {u'l': u'pt', 'd': '10.1590/blabla.pt'},
@@ -3622,27 +3633,6 @@ class ArticleTests(unittest.TestCase):
         article = Article(doc)
         self.assertEqual(article.doi_and_lang, expected)
 
-    def test_doi_and_lang_from_data(self):
-        data = [
-            {u'l': u'pt', 'd': '10.1590/blabla.pt'},
-            {u'l': u'en', 'd': '10.1590/blabla.en'},
-            {u'l': u'es', 'd': '10.1590/blabla.es'},
-        ]
-        expected = [
-            ('pt', '10.1590/blabla.pt'),
-            ('en', '10.1590/blabla.en'),
-            ('es', '10.1590/blabla.es'),
-        ]
-
-        doc = {}
-        doc['article'] = {}
-        doc['article']['v40'] = [{'_': 'pt'}]
-        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
-        doc['article']['v337'] = data
-        article = Article(doc)
-        article.data['doi_and_lang'] = data
-        self.assertEqual(article.doi_and_lang, expected)
-
     def test_doi_and_lang_from_v337_with_bad_format(self):
         data = [
             {u'l': u'pt', 'd': '10.1590/blabla.pt'},
@@ -3660,24 +3650,6 @@ class ArticleTests(unittest.TestCase):
         doc['article']['v337'] = data
         article = Article(doc)
 
-        self.assertEqual(article.doi_and_lang, expected)
-
-    def test_doi_and_lang_from_data_with_bad_format(self):
-        data = [
-            {u'l': u'pt', 'd': '10.1590/blabla.pt'},
-            {u'l': u'en', 'd': '10.1590/blabla.en'},
-            {u'l': u'es', 'd': 'blabla.es'},
-        ]
-        expected = [
-            ('pt', '10.1590/blabla.pt'),
-            ('en', '10.1590/blabla.en'),
-        ]
-        doc = {}
-        doc['article'] = {}
-        doc['article']['v40'] = [{'_': 'pt'}]
-        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
-        article = Article(doc)
-        article.data['doi_and_lang'] = data
         self.assertEqual(article.doi_and_lang, expected)
 
     def test_doi_and_lang_exist_v237_in_v337(self):

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2065,7 +2065,6 @@ class Article(object):
         if 'v237' in self.data['article']:
             raw_doi = self.data['article']['v237'][0]['_']
 
-
         if not raw_doi:
             return None
 
@@ -2079,18 +2078,16 @@ class Article(object):
         """
         This method retrieves the lang and DOI.
         """
-        raw_doi = self.data.get('doi_and_lang') or \
-            self.data.get('article', {}).get('v337')
-        if raw_doi:
-            items = [
+        raw_doi = self.data.get('article', {}).get('v337')
+        items = [
                 (item.get('l'), item.get('d'))
                 for item in raw_doi or []
                 if len(DOI_REGEX.findall(item.get('d'))) == 1
             ]
-            item = (self.original_language(), self.doi)
-            if all(item) and item not in items:
-                items.insert(0, item)
-            return items
+        item = (self.original_language(), self.doi)
+        if all(item) and item not in items:
+            items.insert(0, item)
+        return items
 
     @property
     def publisher_id(self):


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o atributo **doi_and_lang** que não estava retornando doi e lang se há somente 1 DOI (campo v237), ou seja, ausência do campo v337, que foi criado apenas a partir da versão XC 2019 (29/03/2019)

#### Onde a revisão poderia começar?
xylose/scielodocument.py:2077

#### Como este poderia ser testado manualmente?
tests/test_document.py:3606
python setup.py test

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#168 

### Referências
N/A

