### PR TITLE
Troca os valores dos campos que representam DOI para traduções

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requires = [
 
 setup(
     name="xylose",
-    version='1.35.4',
+    version='1.35.5',
     description="A SciELO library to abstract a JSON data structure that is a "
                 "product of the ISIS2JSON conversion using the ISIS2JSON type "
                 "3 data model.",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3679,6 +3679,25 @@ class ArticleTests(unittest.TestCase):
         article = Article(doc)
         self.assertEqual(article.doi_and_lang, expected)
 
+    def test_doi_and_lang_from_v337_and_misplaced(self):
+        data = [
+            {u'd': u'pt', 'l': '10.1590/blabla.pt'},
+            {u'd': u'en', 'l': '10.1590/blabla.en'},
+            {u'd': u'es', 'l': '10.1590/blabla.es'},
+        ]
+        expected = [
+            ('pt', '10.1590/blabla.pt'),
+            ('en', '10.1590/blabla.en'),
+            ('es', '10.1590/blabla.es'),
+        ]
+        doc = {}
+        doc['article'] = {}
+        doc['article']['v40'] = [{'_': 'pt'}]
+        doc['article']['v237'] = [{'_': '10.1590/blabla.pt'}]
+        doc['article']['v337'] = data
+        article = Article(doc)
+        self.assertEqual(article.doi_and_lang, expected)
+
     def test_doi_and_lang_from_v337_with_bad_format(self):
         data = [
             {u'l': u'pt', 'd': '10.1590/blabla.pt'},
@@ -5355,9 +5374,9 @@ class CitationTest(unittest.TestCase):
 
     def test_citation_sample_congress(self):
 
-        json_citation= {u'v999': 
+        json_citation= {u'v999':
             [{u'_': u'../bases-work/ciedu/ciedu'}],
-             u'v12': 
+             u'v12':
                 [{u'l': u'es',
                 u'_': u'Escuelas con poblaciones en riesgo social: proyecto de intervenci\xf3n e investigaci\xf3n en el \xe1rea de ciencias naturales'}], u'v10': [{u's': u'G\xd3MEZ',
                 u'r': u'ND',

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -1843,7 +1843,7 @@ class Article(object):
         to generate production reports, for instance, identify which journals
         are early or late.
 
-        The issue_publication_date is a date which is expected to have a new 
+        The issue_publication_date is a date which is expected to have a new
         issue; it is not necessarily a exact date; it is a range of date,
         for instances, Summer 2009 or Apr-June 2009. It is more like a label
         than a date.
@@ -2135,11 +2135,14 @@ class Article(object):
         This method retrieves the lang and DOI.
         """
         raw_doi = self.data.get('article', {}).get('v337')
-        items = [
-                (item.get('l'), item.get('d'))
-                for item in raw_doi or []
-                if len(DOI_REGEX.findall(item.get('d'))) == 1
-            ]
+        items = []
+        for item in raw_doi or []:
+            lang = item.get("l")
+            doi = item.get("d")
+            if len(DOI_REGEX.findall(lang)) == 1 and len(doi) == 2:
+                lang, doi = doi, lang
+            if len(DOI_REGEX.findall(doi)) == 1 and len(lang) == 2:
+                items.append((lang, doi))
         if self.doi:
             item = (self.original_language(), self.doi)
             if all(item) and item not in items:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige os valores dos subcampos de v337: o subcampo l deve conter o idioma, o subcampo d deve conter o DOI.

#### Onde a revisão poderia começar?
`tests/test_document.py L:3682`

#### Como este poderia ser testado manualmente?
`python setup.py test -s tests.test_document.ArticleTests.test_doi_and_lang_from_v337_and_misplaced`

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#177

### Referências
n/a
