### PR TITLE
Interpreta subcampos de afiliação e autor de artigos

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3208,6 +3208,7 @@ class ArticleTests(unittest.TestCase):
                 'country': u'BRAZIL',
                 'country_iso_3166': 'BR',
                 'email': u'caioisola@yahoo.com.br',
+                'postal_code': u'18052-780',
                 'state': u'SP',
                 'orgdiv1': u'Departamento de Ci\xeancias Biol\xf3gicas',
                 'institution': u'UNIVERSIDADE FEDERAL DE SAO CARLOS'
@@ -3217,6 +3218,7 @@ class ArticleTests(unittest.TestCase):
                 'country': u'BRAZIL',
                 'country_iso_3166': 'BR',
                 'email': u'alex_peressin@yahoo.com.br',
+                'postal_code': u'18052-780',
                 'state': u'SP',
                 'orgdiv1': u'Programa de P\xf3s-Gradua\xe7\xe3o em Diversidade Biol\xf3gica e Conserva\xe7\xe3o',
                 'institution': u'UNIVERSIDADE FEDERAL DE SAO CARLOS'
@@ -3226,6 +3228,7 @@ class ArticleTests(unittest.TestCase):
                 'country': u'BRAZIL',
                 'country_iso_3166': 'BR',
                 'email': u'mcetra@ufscar.br',
+                'postal_code': u'18052-780',
                 'state': u'SP',
                 'orgdiv1': u'Departamento de Ci\xeancias Ambientais',
                 'institution': u'UNIVERSIDADE FEDERAL DE SAO CARLOS'
@@ -3264,7 +3267,9 @@ class ArticleTests(unittest.TestCase):
                 'country': u'BRAZIL',
                 'country_iso_3166': 'BR',
                 'orgdiv2': u'Departamento de Ci\xeancias Ambientais 2',
-                'email': u'mcetra@ufscar.br', 'state': u'SP',
+                'email': u'mcetra@ufscar.br',
+                'postal_code': u'18052-780',
+                'state': u'SP',
                 'orgdiv1': u'Departamento de Ci\xeancias Ambientais 1',
                 'institution': ''
             }
@@ -3306,6 +3311,7 @@ class ArticleTests(unittest.TestCase):
         expected = [
             {
                 'index': u'A01',
+                'label': u'a',
                 'city': u'México',
                 'state': u'D.F.',
                 'country': u'Mexico',

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -2893,6 +2893,32 @@ class ArticleTests(unittest.TestCase):
                    ]
         self.assertEqual(article.authors, authors)
 
+    def test_author_orcid_prefix_suffix(self):
+        self.article.data["article"]["v10"] = [
+            {
+                u"1": u"A01",
+                u"s": u"Diferente",
+                u"r": u"ND",
+                u"_": u"",
+                u"k": u"0000-1111-2222-3333",
+                u"p": u"Sr.",
+                u"z": u"Junior",
+                u"n": u"Fulano",
+            },
+        ]
+        expected = [
+            {
+                u"role": u"ND",
+                u"xref": [u"A01"],
+                u"orcid": u"0000-1111-2222-3333",
+                u"prefix": u"Sr.",
+                u"surname": u"Diferente",
+                u"given_names": u"Fulano",
+                u"suffix": u"Junior",
+            }
+        ]
+        self.assertEqual(self.article.authors, expected)
+
     def test_author_with_two_affiliations(self):
         article = self.article
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3246,6 +3246,49 @@ class ArticleTests(unittest.TestCase):
         self.maxDiff = None
         self.assertEqual(article.affiliations, expected)
 
+    def test_affiliation_subfields(self):
+        self.article.data["article"]["v70"] = [
+            {
+                u"_": u"Universidade XYZ (BR)",
+                u"d": u"A",
+                u"1": u"Faculdade A",
+                u"2": u"Departamento W",
+                u"3": u"Grupo N",
+                u"4": u"Universidade XYZ",
+                u"8": u"s1",
+                u"9": u"Universidade XYZ do Brasil - Faculdade A - W/N",
+                u"e": u"awn@xyz.br",
+                u"c": u"Campinas",
+                u"p": u"BR",
+                u"q": u"Brasil",
+                u"s": u"SP",
+                u"z": u"01234-567",
+                u"i": u"A01",
+                u"l": u"x",
+            },
+        ]
+        expected = [
+            {
+                u"institution": u"Universidade XYZ (BR)",
+                u"division": u"A",
+                u"orgdiv1": u"Faculdade A",
+                u"orgdiv2": u"Departamento W",
+                u"orgdiv3": u"Grupo N",
+                u"normalized": u"Universidade XYZ",
+                u"c8": u"s1",
+                u"original": u"Universidade XYZ do Brasil - Faculdade A - W/N",
+                u"email": u"awn@xyz.br",
+                u"city": u"Campinas",
+                u"country_iso_3166": u"BR",
+                u"country": u"Brazil",
+                u"state": u"SP",
+                u"postal_code": u"01234-567",
+                u"index": u"A01",
+                u"label": u"x",
+            }
+        ]
+        self.assertEqual(self.article.affiliations, expected)
+
     def test_affiliation_without_affiliation_name(self):
         article = self.article
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2316,6 +2316,10 @@ class Article(object):
                     authordict['xref'] = html_decode(author['1'].split(' '))
                 if 'k' in author:
                     authordict['orcid'] = html_decode(author['k'])
+                if 'p' in author:
+                    authordict['prefix'] = html_decode(author['p'])
+                if 'z' in author:
+                    authordict['suffix'] = html_decode(author['z'])
 
                 authors.append(authordict)
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2461,6 +2461,14 @@ class Article(object):
                     affdict['orgdiv1'] = html_decode(aff['1'])
                 if '2' in aff:
                     affdict['orgdiv2'] = html_decode(aff['2'])
+                if '3' in aff:
+                    affdict['orgdiv3'] = html_decode(aff['3'])
+                if '4' in aff:
+                    affdict['normalized'] = html_decode(aff['4'])
+                if '8' in aff:
+                    affdict['c8'] = html_decode(aff['8'])  # Either1/c1/p/s/s1
+                if '9' in aff:
+                    affdict['original'] = html_decode(aff['9'])
                 if 'l' in aff:
                     affdict['label'] = html_decode(aff['l'])
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2442,6 +2442,8 @@ class Article(object):
                     affdict['city'] = html_decode(aff['c'])
                 if 's' in aff:
                     affdict['state'] = html_decode(aff['s'])
+                if 'z' in aff:
+                    affdict['postal_code'] = html_decode(aff['z'])
                 if 'p' in aff:
                     affdict['country'] = html_decode(aff['p'])
                     if html_decode(aff['p']).lower() in iso3166.COUNTRY_CODES_ALPHA_2_FORMS:
@@ -2459,6 +2461,8 @@ class Article(object):
                     affdict['orgdiv1'] = html_decode(aff['1'])
                 if '2' in aff:
                     affdict['orgdiv2'] = html_decode(aff['2'])
+                if 'l' in aff:
+                    affdict['label'] = html_decode(aff['l'])
 
                 affiliations.append(affdict)
 


### PR DESCRIPTION
#### O que esse PR faz?

* Interpreta os subcampos `^p` e `^z` do campo `v10` (autor);
* Interpreta os subcampos `^z`, `^l`, `^3`, `^4`, `^8`, `^9` do campo `v70` (afiliação);
* Corrige os testes que continham o `^z` e o `^l` mas não esperavam a interpretação dos mesmos;
* Insere testes para os novos subcampos, e também para o subcampo `^k` do `v10`, que contém o ORCID e não possuía nenhum teste.

#### Como este poderia ser testado manualmente?
Processando os dados de um artigo que possua os campos que passaram a ser interpretados.

#### Algum cenário de contexto que queira dar?
Essas modificações se referem ao que foi descoberto empiricamente nos dias 2019-09-04 e 2019-09-19, campos existentes nos arquivos XML (e no ArticleMeta) mas que somente podiam ser acessados pelo atributo `data`, utilizando a estrutura do ISIS.

### Referências
Relatório 18 do projeto de normalização das afiliações.