### PR TITLE
Adiciona capacidade de remover tag HTML de campo email da afiliação

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3246,6 +3246,37 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.affiliations, expected)
 
+    def test_affiliation_with_valid_html_tag_in_affiliation_email(self):
+        article = self.article
+
+        del(article.data['article']['v70'])
+
+        article.data['article']['v70'] = [
+            {
+                u"c": u"Sorocaba",
+                u"e": u'<A HREF="mailto:mcetra@ufscar.br">mcetra@ufscar.br</A>',
+                u"i": u"A03",
+                u"1": u"Departamento de Ci\u00eancias Ambientais 1",
+                u"2": u"Departamento de Ci\u00eancias Ambientais 2",
+                u"p": u"BRAZIL",
+                u"s": u"SP",
+                u"z": u"18052-780"}]
+
+        expected = [
+            {
+                'index': u'A03',
+                'city': u'Sorocaba',
+                'country': u'BRAZIL',
+                'country_iso_3166': 'BR',
+                'orgdiv2': u'Departamento de Ci\xeancias Ambientais 2',
+                'email': u'mcetra@ufscar.br', 'state': u'SP',
+                'orgdiv1': u'Departamento de Ci\xeancias Ambientais 1',
+                'institution': ''
+            }
+        ]
+
+        self.assertEqual(article.affiliations, expected)
+
     def test_affiliation_just_with_affiliation_name(self):
         article = self.article
 

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2463,7 +2463,10 @@ class Article(object):
                     affdict['country_iso_3166'] = aff['p']
 
                 if 'e' in aff:
-                    affdict['email'] = email_html_remove(html_decode(aff['e']))
+                    affdict['email'] = html_decode(aff['e'])
+                    email_html_removed = email_html_remove(html_decode(aff['e']))
+                    if email_html_removed != affdict['email']:
+                        affdict['email_html_removed'] = email_html_removed
                 if 'd' in aff:
                     affdict['division'] = html_decode(aff['d'])
                 if '1' in aff:

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -48,6 +48,10 @@ REPLACE_TAGS_MIXED_CITATION = (
     (re.compile(r'< *?small.*?>', re.IGNORECASE), '<small>',),
     (re.compile(r'< *?/ *?small.*?>', re.IGNORECASE), '</small>',),
 )
+EMAIL_REGEX = re.compile(
+    r'(?P<open_anchor>a href)=(?P<href>\".*\")>(?P<email>.*)<(?P<close_anchor>\/a|\/A)',
+    re.IGNORECASE
+)
 
 
 def warn_future_deprecation(old, new, details=''):
@@ -101,6 +105,17 @@ def html_decode(string):
 
     try:
         return remove_control_characters(string)
+    except:
+        return string
+
+
+def email_html_remove(string):
+    result = EMAIL_REGEX.search(string)
+    if result is None:
+        return string
+
+    try:
+        return result.group("email")
     except:
         return string
 
@@ -2448,7 +2463,7 @@ class Article(object):
                     affdict['country_iso_3166'] = aff['p']
 
                 if 'e' in aff:
-                    affdict['email'] = html_decode(aff['e'])
+                    affdict['email'] = email_html_remove(html_decode(aff['e']))
                 if 'd' in aff:
                     affdict['division'] = html_decode(aff['d'])
                 if '1' in aff:


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a capacidade de remover tags HTML de campos de email das afiliações.
Por conta da marcação de artigos HTML, muitos emails de afiliações foram marcados com a tag HTML de âncora, armazenando no campo `['article']['v70']['e']` o endereço de email com a tag `<a>`. Esta sanitização do campo extrai somente o conteúdo de tags HTML válidas, não tratando dos casos em que não é possível ler o HTML corretamente. Para estes, a *property* `Article.affiliations` retorna exatamente como está na base ISIS.

#### Onde a revisão poderia começar?
Em `tests/test_document.py`, onde é possível visualizar um caso de afiliação com o campo email dentro da tag HTML.

#### Como este poderia ser testado manualmente?
Executando `python setup.py test -s tests.test_document.ArticleTests`
OU
Criando uma instância de `xylose.scielodocument.Article()` com os dados de um artigo no formato ISIS/JSON que possua afiliação com tag HTML no campo de email. Ex.: `S0073-47212007000200001`

#### Algum cenário de contexto que queira dar?
Este problema foi notado durante o desenvolvimento do DS Migração, acessando a API REST do formato `xmlrsps` do Article Meta.

### Screenshots
N/A

#### Quais são tickets relevantes?
scieloorg/articles_meta/issues/185

### Referências
Nenhuma.
