### PR TITLE
Corrige a decodicação de tags HTML ao acessar a propriedade `mixed_citations`

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -5548,7 +5548,7 @@ class CitationTest(unittest.TestCase):
         self.assertEqual(citation.link, u'<http://files.eric.ed.gov/fulltext/ED405219.pdf >')
         self.assertEqual(citation.comment, u'Disponible en: <ext-link ext-link-type="uri" ns0:href="&lt;http://files.eric.ed.gov/fulltext/ED405219.pdf &gt;">&lt;http://files.eric.ed.gov/fulltext/ED405219.pdf &gt;</ext-link>')
         self.assertEqual(citation.link_access_date, u'Visitado el: 18 Jul. 2014')
-        self.assertEqual(citation.mixed_citation, u"CHUNG-CHIH CHEN, C. C.; TAYLOR, P. C.; ALDRIDGE, J. M. Development of a questionnaire for assessing teachers' beliefs about science and science teaching in Taiwan and Australia. In: ANNUAL MEETING OF THE NATIONAL ASSOCIATION FOR RESEARCH IN SCIENCE TEACHING, Oak Brook, 1997. Disponible en: <http://files.eric.ed.gov/fulltext/ED405219.pdf >. Visitado el: 18 Jul. 2014.")
+        self.assertEqual(citation.mixed_citation, u"CHUNG-CHIH CHEN, C. C.; TAYLOR, P. C.; ALDRIDGE, J. M. Development of a questionnaire for assessing teachers' beliefs about science and science teaching in Taiwan and Australia. In: ANNUAL MEETING OF THE NATIONAL ASSOCIATION FOR RESEARCH IN SCIENCE TEACHING, Oak Brook, 1997. Disponible en: &lt;http://files.eric.ed.gov/fulltext/ED405219.pdf &gt;. Visitado el: 18 Jul. 2014.")
 
     def test_citation_sample_link_without_comment(self):
 
@@ -5560,7 +5560,7 @@ class CitationTest(unittest.TestCase):
         self.assertEqual(citation.link, u'<http://files.eric.ed.gov/fulltext/ED405219.pdf >')
         self.assertEqual(citation.comment, u'Available at: <ext-link ext-link-type="uri" ns0:href="<http://files.eric.ed.gov/fulltext/ED405219.pdf >"><http://files.eric.ed.gov/fulltext/ED405219.pdf ></ext-link>')
         self.assertEqual(citation.link_access_date, u'Visitado el: 18 Jul. 2014')
-        self.assertEqual(citation.mixed_citation, u"CHUNG-CHIH CHEN, C. C.; TAYLOR, P. C.; ALDRIDGE, J. M. Development of a questionnaire for assessing teachers' beliefs about science and science teaching in Taiwan and Australia. In: ANNUAL MEETING OF THE NATIONAL ASSOCIATION FOR RESEARCH IN SCIENCE TEACHING, Oak Brook, 1997. Disponible en: <http://files.eric.ed.gov/fulltext/ED405219.pdf >. Visitado el: 18 Jul. 2014.")
+        self.assertEqual(citation.mixed_citation, u"CHUNG-CHIH CHEN, C. C.; TAYLOR, P. C.; ALDRIDGE, J. M. Development of a questionnaire for assessing teachers' beliefs about science and science teaching in Taiwan and Australia. In: ANNUAL MEETING OF THE NATIONAL ASSOCIATION FOR RESEARCH IN SCIENCE TEACHING, Oak Brook, 1997. Disponible en: &lt;http://files.eric.ed.gov/fulltext/ED405219.pdf &gt;. Visitado el: 18 Jul. 2014.")
 
     def test_citation_sample_congress(self):
 


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request limita a decodificação de entidades HTML ao acessarmos a propriedade `mixed_citations` dos artigos. O [comentário](https://github.com/scieloorg/articles_meta/issues/217#issuecomment-613043107) demonstra a necessidade desta alteração.

#### Onde a revisão poderia começar?
- `xylose/scielodocument.py` L: `37`.

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/articles_meta/issues/217

### Referências
N/A


