### PR TITLE
Refactor: collection summary api

### DIFF
--- a/xylose/choices.py
+++ b/xylose/choices.py
@@ -102,36 +102,6 @@ periodicity_in_months = {
     u'Z': u'undefined'
 }
 
-collections = {
-    'scl': ['Brazil', 'www.scielo.br'],
-    'arg': ['Argentina', 'www.scielo.org.ar'],
-    'cub': ['Cuba', 'scielo.sld.cu'],
-    'esp': ['Spain', 'scielo.isciii.es'],
-    'col': ['Colombia', 'www.scielo.org.co'],
-    'sss': ['Social Sciences', 'socialsciences.scielo.org'],
-    'spa': ['Public Health', 'www.scielosp.org'],
-    'mex': ['Mexico', 'www.scielo.org.mx'],
-    'prt': ['Portugal', 'www.scielo.mec.pt'],
-    'cri': ['Costa Rica', 'www.scielo.sa.cr'],
-    'ven': ['Venezuela', 'www.scielo.org.ve'],
-    'ury': ['Uruguay', 'www.scielo.edu.uy'],
-    'per': ['Peru', 'www.scielo.org.pe'],
-    'chl': ['Chile', 'www.scielo.cl'],
-    'sza': ['South Africa', 'www.scielo.org.za'],
-    'bol': ['Bolivia', 'www.scielo.org.bo'],
-    'pry': ['Paraguay', 'scielo.iics.una.py'],
-    'psi': ['PEPSIC', 'pepsic.bvsalud.org'],
-    'ppg': ['PPEGEO', 'ppegeo.igc.usp.br'],
-    'rve': ['RevOdonto', 'revodonto.bvsalud.org'],
-    'edc': ['Educa', 'educa.fcc.org.br'],
-    'inv': [u'Inovação', 'inovacao.scielo.br'],
-    'cic': [u'Ciência e Cultura', 'cienciaecultura.bvs.br'],
-    'cci': [u'ComCiência', 'comciencia.scielo.br'],
-    'wid': ['West Indians', 'caribbean.scielo.org'],
-    'pro': ['Proceedings', 'www.proceedings.scielo.br'],
-    'ecu': ['Ecuador', 'scielo.senescyt.gob.ec'],
-}
-
 journal_status = {
     'c': u'current',
     'd': u'deceased',

--- a/xylose/choices.py
+++ b/xylose/choices.py
@@ -191,3 +191,38 @@ month_bad_prediction = {
     u'diciembre': 12,
     u'december': 12
 }
+
+
+def fetch_collection_metadata(collection_code):
+    """
+    Fetch metadata for a given SciELO collection code from the ArticleMeta API.
+
+    Args:
+        collection_code (str): SciELO collection code (e.g., 'ven', 'scl').
+
+    Returns:
+        dict or None: JSON metadata if successful, None otherwise.
+    """
+    if not isinstance(collection_code, str) or not collection_code.strip():
+        return None
+
+    base_url = "https://articlemeta.scielo.org"
+    endpoint = f"/api/v1/collection/?code={collection_code}"
+    full_url = f"{base_url}{endpoint}"
+
+    session = requests.Session()
+    retry_policy = Retry(
+        total=3,
+        backoff_factor=1,
+        status_forcelist=[500, 502, 503, 504],
+        allowed_methods=["GET"]
+    )
+    adapter = HTTPAdapter(max_retries=retry_policy)
+    session.mount(base_url, adapter)
+
+    try:
+        response = session.get(full_url, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except (requests.RequestException, ValueError):
+        return None

--- a/xylose/choices.py
+++ b/xylose/choices.py
@@ -226,3 +226,25 @@ def fetch_collection_metadata(collection_code):
         return response.json()
     except (requests.RequestException, ValueError):
         return None
+
+
+def get_collection_name_and_url(metadata):
+    """
+    Extract the collection's original name and display URL from metadata.
+
+    Args:
+        metadata (dict): Metadata dictionary returned by the API.
+
+    Returns:
+        list[str]: [original_name, formatted_url] or an empty list on failure.
+    """
+    if not isinstance(metadata, dict):
+        return []
+
+    try:
+        name = metadata["original_name"]
+        acron2 = metadata["acron2"]
+        url = f"www.scielo.org.{acron2}"
+        return [name, url]
+    except KeyError:
+        return []

--- a/xylose/choices.py
+++ b/xylose/choices.py
@@ -248,3 +248,17 @@ def get_collection_name_and_url(metadata):
         return [name, url]
     except KeyError:
         return []
+
+
+def get_collection_summary(collection_code):
+    """
+    Retrieve a summarized list with the collection's name and display URL.
+
+    Args:
+        collection_code (str): SciELO collection code (e.g., 'ven', 'scl').
+
+    Returns:
+        list[str]: [original_name, formatted_url] or an empty list if retrieval fails.
+    """
+    metadata = fetch_collection_metadata(collection_code)
+    return get_collection_name_and_url(metadata) if metadata else []

--- a/xylose/choices.py
+++ b/xylose/choices.py
@@ -1,5 +1,10 @@
 # encoding: utf-8
 
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
 CREATIVE_COMMONS_TEXTS = {
     "BY": "Attribution",
     "BY-ND": "Attribution-NoDerivatives",

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -252,10 +252,8 @@ class Issue(object):
         """
 
         if self.collection_acronym:
-            return choices.collections.get(
-                self.collection_acronym,
-                [u'Undefined: %s' % self.collection_acronym, None]
-            )[1] or None
+            summary = choices.get_collection_summary(self.collection_acronym)
+            return summary[1] if len(summary) > 1 and summary[1] else None
 
         if 'v690' in self.data['title']:
             return self.data['title']['v690'][0]['_'].replace('http://', '')
@@ -1072,10 +1070,8 @@ class Journal(object):
         """
 
         if self.collection_acronym:
-            return choices.collections.get(
-                self.collection_acronym,
-                [u'Undefined: %s' % self.collection_acronym, None]
-            )[1] or None
+            summary = choices.get_collection_summary(self.collection_acronym)
+            return summary[1] if len(summary) > 1 and summary[1] else None
 
         if 'v690' in self.data:
             return self.data['v690'][0]['_'].replace('http://', '')
@@ -1803,10 +1799,9 @@ class Article(object):
         This method retrieves the collection name of the given article,
         if it exists.
         """
-        return choices.collections.get(
-            self.collection_acronym,
-            [u'Undefined: %s' % self.collection_acronym, '']
-        )[0]
+        if self.collection_acronym:
+            summary = choices.get_collection_summary(self.collection_acronym)
+            return summary[0] if len(summary) > 0 and summary[0] else f'Undefined: {self.collection_acronym}'
 
     @property
     def collection_acronym(self):
@@ -2565,10 +2560,8 @@ class Article(object):
         """
 
         if self.collection_acronym:
-            return choices.collections.get(
-                self.collection_acronym,
-                [u'Undefined: %s' % self.collection_acronym, None]
-            )[1] or None
+            summary = choices.get_collection_summary(self.collection_acronym)
+            return summary[0] if len(summary) > 0 and summary[0] else f'Undefined: {self.collection_acronym}'
 
         if 'v690' in self.data['title']:
             return self.data['title']['v690'][0]['_'].replace('http://', '')


### PR DESCRIPTION
#### O que esse PR faz?
Refatora o uso do dicionário local choices.collections substituindo-o por chamadas à função `get_collection_summary`, que consulta diretamente a API do ArticleMeta para obter o nome e a URL da coleção.

#### Onde a revisão poderia começar?
A revisão pode começar pelos trechos onde `choices.collections.get(...)` era utilizado - normalmente em métodos que retornam o nome ou a URL da coleção com base em `self.collection_acronym`.
Os pontos alterados fazem uso agora da função `get_collection_summary`, definida no módulo utilitário `xylose/choices.py`.

#### Como este poderia ser testado manualmente?
1. Execute a aplicação normalmente.
2. Acesse funcionalidades que envolvem dados da coleção (ex: exibição de nome e URL).
3. Verifique que:
    -   Para acrônimos válidos (como "ven"), o nome e o domínio aparecem corretamente.
    -   Para acrônimos inexistentes, o nome aparece como "Undefined: <sigla>" e a URL como None.

#### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

#### Quais são tickets relevantes?
TK #198 

### Referências
NA.
