### PR TITLE
Add related_documents property and tests to Article

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3828,16 +3828,14 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.related_documents, [
             {
-                u'identifier': u'10.1590/S2237-96222025v34e20240180.a',
-                u'document_type': u'reviewer-report',
-                u'label': u'',
-                u'identifier_type': u'doi'
+                u'id': u'10.1590/S2237-96222025v34e20240180.a',
+                u'related_article_type': u'reviewer-report',
+                u'ext_link_type': u'doi'
             },
             {
-                u'identifier': u'10.1590/S2237-96222025v34e20240180.b',
-                u'document_type': u'corrected-article',
-                u'label': u'',
-                u'identifier_type': u'doi'
+                u'id': u'10.1590/S2237-96222025v34e20240180.b',
+                u'related_article_type': u'corrected-article',
+                u'ext_link_type': u'doi'
             }
         ])
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -3808,6 +3808,44 @@ class ArticleTests(unittest.TestCase):
 
         self.assertEqual(article.thesis_organization, None)
 
+    def test_related_documents(self):
+        self.fulldoc['article']['v241'] = [
+            {
+                u'i': u'10.1590/S2237-96222025v34e20240180.a',
+                u't': u'reviewer-report',
+                u'_': u'',
+                u'n': u'doi'
+            },
+            {
+                u'i': u'10.1590/S2237-96222025v34e20240180.b',
+                u't': u'corrected-article',
+                u'_': u'',
+                u'n': u'doi'
+            }
+        ]
+
+        article = Article(self.fulldoc)
+
+        self.assertEqual(article.related_documents, [
+            {
+                u'identifier': u'10.1590/S2237-96222025v34e20240180.a',
+                u'document_type': u'reviewer-report',
+                u'label': u'',
+                u'identifier_type': u'doi'
+            },
+            {
+                u'identifier': u'10.1590/S2237-96222025v34e20240180.b',
+                u'document_type': u'corrected-article',
+                u'label': u'',
+                u'identifier_type': u'doi'
+            }
+        ])
+
+    def test_without_related_documents(self):
+        article = Article(self.fulldoc)
+
+        self.assertEqual(article.related_documents, None)
+
     @unittest.skip('skip test_citations')
     def test_citations(self):
         article = self.article

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2669,6 +2669,31 @@ class Article(object):
             return organizations
 
     @property
+    def related_documents(self):
+        """
+        This method retrieves documents related to the given article, such as
+        reviewer reports, retractions, corrections, commentaries, and preprints.
+        This method deals with the legacy fields (241).
+        """
+        if 'v241' in self.data['article']:
+            related_documents = []
+            for related_document in self.data['article'].get('v241'):
+                item = {}
+                if 'i' in related_document:
+                    item['identifier'] = related_document['i']
+                if 't' in related_document:
+                    item['document_type'] = related_document['t']
+                if 'n' in related_document:
+                    item['identifier_type'] = related_document['n']
+                if '_' in related_document:
+                    item['label'] = html_decode(related_document['_'])
+
+                related_documents.append(item)
+
+            if len(related_documents) > 0:
+                return related_documents
+
+    @property
     def citations(self):
         """
         This method retrieves a list with all the citation objects of the given article.

--- a/xylose/scielodocument.py
+++ b/xylose/scielodocument.py
@@ -2680,13 +2680,11 @@ class Article(object):
             for related_document in self.data['article'].get('v241'):
                 item = {}
                 if 'i' in related_document:
-                    item['identifier'] = related_document['i']
+                    item['id'] = related_document['i']
                 if 't' in related_document:
-                    item['document_type'] = related_document['t']
+                    item['related_article_type'] = related_document['t']
                 if 'n' in related_document:
-                    item['identifier_type'] = related_document['n']
-                if '_' in related_document:
-                    item['label'] = html_decode(related_document['_'])
+                    item['ext_link_type'] = related_document['n']
 
                 related_documents.append(item)
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a property related_documents na classe Article para expor os metadados do campo legado v241, que representa documentos relacionados a um artigo.

A property abstrai a estrutura ISIS2JSON e retorna uma lista de dicionários com chaves legíveis:

- id — identificador do documento (ex.: DOI)
- related_article_type — tipo do documento relacionado
- ext_link_type — tipo do identificador (ex.: doi)


Suporta diversos valores de document_type, como reviewer-report, corrected-article, retracted-article, addended-article, expression-of-concern, commentary-article, reply, reviewed-article e preprint.

Retorna None quando o campo v241 não existe ou está vazio.

#### Onde a revisão poderia começar?
Comece por xylose/scielodocument.py, na property related_documents (próximo a thesis_organization e citations).

Em seguida, veja os testes em tests/test_document.py: test_related_documents e test_without_related_documents.

#### Como este poderia ser testado manualmente?

1. Instale o pacote em modo de desenvolvimento: 
```python
 pip install -e .
```
2. Abra um shell Python e carregue um documento JSON com o campo v241:
```python
from xylose.scielodocument import Article

data = {
    'article': {
        'v241': [
            {'i': '10.1590/S2237-96222025v34e20240180.a', 't': 'reviewer-report', '_': '', 'n': 'doi'},
            {'i': '10.1590/S2237-96222025v34e20240180.b', 't': 'corrected-article', '_': '', 'n': 'doi'},
        ]
    }
}

article = Article(data)
print(article.related_documents)
```
3. Verifique se o retorno contém as chaves identifier, document_type, identifier_type e label.
4. Teste um documento sem v241 e confirme que retorna None.
5. (Opcional) Rode os testes automatizados:
```python
python3 -m unittest tests.test_document.ArticleTests.test_related_documents tests.test_document.ArticleTests.test_without_related_documents
```

#### Quais são tickets relevantes?
https://github.com/scieloorg/articles_meta/issues/329

### Referências

https://docs.google.com/document/d/1GTv4Inc2LS_AXY-ToHT3HmO66UT0VAHWJNOIqzBNSgA/edit?pli=1&tab=t.0#heading=h.2upcpyuv6r4o

---

## Segurança da informação (NSI.04)

> Seção obrigatória. Marque as opções aplicáveis e justifique quando necessário. Referência: NSI.04 - Norma de Desenvolvimento Seguro.

**Este PR manipula dados sensíveis ou pessoais (LGPD)?**
- [ ] Sim — descreva os controles de proteção aplicados (criptografia, mascaramento, anonimização, etc.):
- [x] Não

**Este PR altera autenticação, autorização, controle de acesso ou gerenciamento de sessão?**
- [ ] Sim — descreva o que mudou e por quê:
- [x] Não

**Este PR introduz, atualiza ou remove dependências de terceiros?**
- [ ] Sim — as novas dependências foram verificadas no SBOM/Trivy sem vulnerabilidades críticas/altas em aberto?
  - [ ] Verificado e aprovado
  - [ ] Pendente / vulnerabilidade aceita com justificativa: 
- [x] Não

**Este PR foi validado pelo pipeline de segurança (SonarQube / Trivy)?**
- [ ] Sim — link do job:
- [x] Não aplicável a este PR (justifique):

**Este PR concatena, monta ou executa comandos SQL, HTML ou JavaScript a partir de entrada externa?**
- [ ] Sim — confirme que há sanitização/parametrização (prepared statements, escaping, etc.):
- [x] Não

**Este PR expõe novos endpoints, telas ou serviços?**
- [ ] Sim — HTTPS obrigatório está garantido e o acesso segue o princípio de menor privilégio?
- [x] Não

**Algum segredo, senha, chave ou token está sendo adicionado ao código-fonte?**
- [x] Não, nenhum segredo foi commitado
- [ ] Sim (bloquear merge e corrigir antes de prosseguir)

